### PR TITLE
Pretty-print Coq's vernac AST

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,21 @@ https://vstyle.readthedocs.io
 # Building & running
 
 ```console
-$ dune build
-$ ./_build/default/src/coqformat.exe --help
+$ cd src
+/src$ dune build
+/src$ ./_build/default/coqformat.exe --help
 ```
 
 # Example
 
 ```console
-$ ./_build/default/src/coqformat.exe examples/Foo.v
+$ cd src
+/src$ ./_build/default/coqformat.exe ../examples/Foo.v
 ```
 
 # Formatting the source
 
 ```console
-$ dune build @fmt --auto-promote
+$ cd src
+/src$ dune build @fmt --auto-promote
 ```

--- a/examples/Foo.v
+++ b/examples/Foo.v
@@ -18,9 +18,9 @@ Definition add_em (x y: nat):
  := x + y
 .
 
-Arguments add_em [_].
+Definition add_em_2 x := add_em x.
 
-Definition add_em_2 := add_em.
+Arguments add_em [_].
 
 From Coq Require Import Lists.List.
 Import ListNotations.
@@ -51,3 +51,11 @@ Definition negative_sixteen: Z := -0X1_0.
 Require Import Coq.Floats.Floats.
 
 Definition fiftytwo: float := 5.2e1.
+
+Definition fiftytwo_2: float := 5.2E1.
+
+Definition fifty: float := 5E1.
+
+From Coq Require Import Strings.String.
+
+Definition a_string: string := ("foo")%string.

--- a/src/formatter.ml
+++ b/src/formatter.ml
@@ -1,27 +1,3 @@
-let load_file f =
-  let ic = open_in f in
-  let n = in_channel_length ic in
-  let s = Bytes.create n in
-  really_input ic s 0 n;
-  close_in ic;
-  s
-
-let rec stream_tok n_tok acc str source begin_line begin_char =
-  let e = LStream.next str in
-  let pre_loc : Loc.t = LStream.get_loc n_tok str in
-  let loc =
-    {
-      pre_loc with
-      fname = source;
-      line_nb = begin_line;
-      line_nb_last = begin_line + pre_loc.line_nb_last - 1;
-      bp = begin_char + pre_loc.bp;
-      ep = begin_char + pre_loc.ep;
-    }
-  in
-  let l_tok = CAst.make ~loc e in
-  if Tok.(equal e EOI) then List.rev acc else stream_tok (n_tok + 1) (l_tok :: acc) str source begin_line begin_char
-
 exception End_of_input
 
 let format_doc ~in_file ~in_chan ~doc ~sid =
@@ -30,33 +6,22 @@ let format_doc ~in_file ~in_chan ~doc ~sid =
   let in_strm = Stream.of_channel in_chan in
   let source = Loc.InFile in_file in
   let in_pa = Pcoq.Parsable.make ~loc:(Loc.initial source) in_strm in
-  let in_bytes = load_file in_file in
   try
     while true do
-      let l_pre_st = CLexer.Lexer.State.get () in
       let doc, sid = !stt in
       let ast =
         match Stm.parse_sentence ~doc ~entry:Pvernac.main_entry sid in_pa with
         | Some ast -> ast
         | None -> raise End_of_input
       in
-      let begin_line, begin_char, end_char =
-        match ast.loc with Some lc -> (lc.line_nb, lc.bp, lc.ep) | None -> raise End_of_input
-      in
-      let istr = Bytes.sub_string in_bytes begin_char (end_char - begin_char) in
-      let l_post_st = CLexer.Lexer.State.get () in
-      let sstr = Stream.of_string istr in
+      (* let ast_pp = Ppvernac.pr_vernac_expr ast.v.expr in *)
+      let ast_pp = Ppvernac.pr_vernac ast in
+      printf "%s\n" (Pp.string_of_ppcmds ast_pp);
       try
-        CLexer.Lexer.State.set l_pre_st;
-        let lex = CLexer.Lexer.tok_func sstr in
-        let sen = Sertop.Sertop_ser.Sentence (stream_tok 0 [] lex source begin_line begin_char) in
-        CLexer.Lexer.State.set l_post_st;
-        printf "@[%a@]@\n%!" Printer.pp (Sertop.Sertop_ser.sexp_of_sentence sen);
         let doc, n_st, tip = Stm.add ~doc ~ontop:sid false ast in
         if tip <> `NewTip then CErrors.user_err ?loc:ast.loc Pp.(str "fatal, got no `NewTip`");
         stt := (doc, n_st)
       with exn ->
-        CLexer.Lexer.State.set l_post_st;
         raise exn
     done;
     !stt

--- a/src/formatter.mli
+++ b/src/formatter.mli
@@ -1,5 +1,1 @@
-val load_file : string -> bytes
-
-val stream_tok : int -> Tok.t CAst.t list -> Tok.t LStream.t -> Loc.source -> int -> int -> Tok.t CAst.t list
-
 val format_doc : in_file:string -> in_chan:in_channel -> doc:Stm.doc -> sid:Stateid.t -> Stm.doc * Stateid.t


### PR DESCRIPTION
This PR switches away from using the sertok lexer and towards using the Coq vernac AST.

I tested using `examples/Foo.v`. As can be seen below, the tool strips all comments. However, it also generates a valid `.v` file, which is an improvement over the previous iteration.

Output from `cd src ; dune build && ./_build/default/coqformat.exe ../examples/Foo.v`:

```coq
Definition five : nat := 5.
Lemma five__eq__five : five = 5.
Proof.
easy.
Qed.
Definition add_em (x y : nat) : nat := x + y.
Definition add_em_2 x := add_em x.
Arguments add_em [_].
From Coq Require Import Lists.List.
Import ListNotations.
Definition listy_five : list nat := [five; five].
Fail Require Import SomethingThatDoesNotExist.
Lemma this_is_not_true : 0 = 1.
Proof.
Fail reflexivity.
Admitted.
Unset Printing Notations.
Definition appy := Lists.List.app listy_five listy_five.
Definition sixteen := 0x10.
Require Import Coq.ZArith.ZArith.
Definition negative_sixteen : Z := - 0X1_0.
Require Import Coq.Floats.Floats.
Definition fiftytwo : float := 5.2e1.
Definition fiftytwo_2 : float := 5.2E1.
Definition fifty : float := 5E1.
From Coq Require Import Strings.String.
Definition a_string : string := "foo"%string.
```